### PR TITLE
Add list of existing Java materials for juniors

### DIFF
--- a/javaMaterials.md
+++ b/javaMaterials.md
@@ -1,0 +1,46 @@
+# Java materials
+
+This file holds a list of existing training materials related to Java stack.
+
+## Presentations:
+ * **Introductory slides**:
+    * Introduction [01/2018](https://drive.google.com/open?id=1IHyCOh7BKoGFoY5dHfQ1VpDG8oG6cTeEWJ3HSUkqOeA), [12/2017](https://docs.google.com/presentation/d/1E__g89dsHjzeNVzuPSssq8VdyYBsT_3UWi3cUaqbhU0/edit#slide=id.g2b69b979a0_0_55)
+    
+ * **Spring**:
+    * Spring introduction [01/2018](https://drive.google.com/open?id=1WGp96MynjIGA-gB0KSNg4UeFe1DweKGwEtK7pRXlqO0), [12/2017](https://drive.google.com/open?id=1upn7LPOs6pIiR5jCD8JoGyhmd4Vz4VAg5bUQQSL1qIM)
+    * REST and JDBC in Spring + Liquibase [01/2018](https://drive.google.com/open?id=1rbhL7aKmn3OfwmKBAai8600CU_QhLtt6dMvisJGGeC8), [12/2017](https://drive.google.com/open?id=1ZwiugHgalPRXQ4iqD5WRR_QMLlYAd_FPyEeCP3Pt4dI)
+ * **Testing**:
+    * [Testing with JDBC and EasyMock 12/2017](https://drive.google.com/open?id=1NB7lGd8aIfB78zhV0bEihsoIC631Jpw7KkttiH9TKg8)
+    * [Testing using JUnit and Mockito 01/2018](https://drive.google.com/open?id=1tlik1uRvYfoKG7QXN5zle5UXU5DhW4jfU9I9qwfKRgc)
+ * **JEE**
+    * [Enterprise Java Beans 12/2017](https://drive.google.com/open?id=1zk-Fehs-ifT4VZ42AcA82JYguFMnwCqisvPmCO2J8GE)
+    
+## Materials
+ * [Basics of GIT, how to use GIT in IDEA](https://github.com/cngroupdk/cnu-mars-rover/blob/master/github-manual.md)    
+
+## Sample projects
+ * [Outcomes of Spring tutorials 12/2017](https://github.com/Wrent/CNU-Spring-tutorials)
+ * [CNU 11/2017 homework project](https://github.com/cngroupdk/cnu-mars-rover)
+ * [Sample solution of CNU 12/2017 assignment](https://github.com/Wrent/cnu-spring-entities-service)
+ 
+## Assignments
+ * [CNU 12/2017 assignment](https://docs.google.com/document/d/1DUpz0LPBFzceyvuEId1uXXJlsIWzfY9ky1UlhSh7zO8/edit?usp=sharing)
+ * [Spring training 01/2018 assignment](https://drive.google.com/open?id=16TaF8VRNK_Gby5CPkgZTDZgCJ7t6nXTVHpwDL82Rk00)
+    
+## Study plans
+
+ * [CNU 12/2017 study plan](https://drive.google.com/open?id=1wiSlHwXMQhOsXFIZmu_48nCjOEyBdcQo0JbhtvQYFmQ)
+ 
+## Recommended sources
+
+ * **Spring in Action**, 4th Edition.pdf - especially chapters: 1, 2, 5 (beginning), 10, 16, 21
+ * [Spring Core basics](https://www.tutorialspoint.com/spring/index.htm)
+ * [Spring Boot introduction](https://spring.io/guides/gs/spring-boot/)
+ * [REST in Spring introduction](https://spring.io/guides/gs/rest-service/)
+ * [JDBC in Spring introduction](https://spring.io/guides/gs/relational-data-access/)
+ * [Spring Data introduction](https://projects.spring.io/spring-data/)
+ * [Testing with JUnit and EasyMock](http://www.michaelminella.com/testing/unit-testing-with-junit-and-easymock.html)
+ * [Basics of REST](https://spring.io/understanding/REST)
+ * [How I explained REST to my wife](http://web.archive.org/web/20130116005443/http://tomayko.com/writings/rest-to-my-wife)
+ * [Liquibase introduction](http://www.baeldung.com/liquibase-refactor-schema-of-java-app
+)


### PR DESCRIPTION
We had most of the existing materials in Google docs, so at the moment, I just added links to them. Maybe in the future we can redo the slides to some slide technology, which can be stored directly here.